### PR TITLE
feat(ui): multi-branch-additions

### DIFF
--- a/prototype/frontend/src/components/ContextMenu.tsx
+++ b/prototype/frontend/src/components/ContextMenu.tsx
@@ -30,7 +30,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({ x, y, show, onClose, onBranch
             onClick={handleBranchClick}
             className="block w-full text-left px-4 py-2 text-sm text-foreground hover:bg-accent"
           >
-            Create new branch
+            Add to clipboard
           </button>
         </li>
       </ul>

--- a/prototype/frontend/src/components/HighlightText.tsx
+++ b/prototype/frontend/src/components/HighlightText.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+type Props = {
+  content: string;
+  highlights: string[];
+  messageId: string;
+};
+
+// Render plain text with simple gray <mark> highlights for each phrase.
+// Assumes small, non-overlapping phrases; safe fallback if overlaps occur.
+export default function HighlightText({ content, highlights, messageId }: Props) {
+  if (!highlights || highlights.length === 0) return <p>{content}</p>;
+  let nodes: Array<string | JSX.Element> = [content];
+  highlights.forEach((phrase, idx) => {
+    const next: Array<string | JSX.Element> = [];
+    nodes.forEach((node) => {
+      if (typeof node !== 'string') { next.push(node); return; }
+      if (!phrase) { next.push(node); return; }
+      const parts = node.split(phrase);
+      parts.forEach((p, i) => {
+        if (i > 0) {
+          next.push(
+            <mark key={`h-${messageId}-${idx}-${i}`} className="bg-gray-300 text-foreground rounded px-0.5">{phrase}</mark>
+          );
+        }
+      if (p) next.push(p);
+      });
+    });
+    nodes = next;
+  });
+  return <>{nodes}</>;
+}
+

--- a/prototype/frontend/src/components/sidebar/CapturePanel.tsx
+++ b/prototype/frontend/src/components/sidebar/CapturePanel.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+type Item = { id: string; text: string; checked: boolean };
+
+type Props = {
+  items: Item[];
+  isCollapsed: boolean;
+  onToggleItem: (id: string) => void;
+  onDiscard: () => void;
+  onCreateBranches: () => void;
+  onAddSample: () => void;
+};
+
+export default function CapturePanel({ items, isCollapsed, onToggleItem, onDiscard, onCreateBranches, onAddSample }: Props) {
+  return (
+    <div className="h-full flex flex-col">
+      <div className="p-3 text-sm text-muted-foreground">
+        {isCollapsed ? null : (
+          <p>Captured highlights (placeholder). This will be populated from the chat window later.</p>
+        )}
+      </div>
+      <div className="px-2 flex-1 overflow-y-auto">
+        {items.length === 0 ? (
+          <div className="text-sm text-muted-foreground px-2">
+            No highlights yet.
+            {!isCollapsed && (
+              <button onClick={onAddSample} className="ml-2 text-primary underline">Add sample</button>
+            )}
+          </div>
+        ) : (
+          <ul className="space-y-2">
+            {items.map((item) => (
+              <li key={item.id} className="flex items-start gap-2 p-2 bg-muted rounded">
+                <input
+                  type="checkbox"
+                  checked={item.checked}
+                  onChange={() => onToggleItem(item.id)}
+                  className="mt-1"
+                  aria-label="Select highlight"
+                />
+                <span className="text-sm leading-snug break-words">{item.text}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <div className="p-3 border-t border-border flex items-center justify-end gap-2">
+        <button
+          onClick={onDiscard}
+          className="px-3 py-1.5 text-sm rounded-md bg-destructive text-destructive-foreground hover:opacity-90"
+        >
+          Discard
+        </button>
+        <button
+          onClick={onCreateBranches}
+          className="px-3 py-1.5 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90"
+        >
+          Create new branch
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/prototype/frontend/src/components/sidebar/ChatTree.tsx
+++ b/prototype/frontend/src/components/sidebar/ChatTree.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Chat } from '../TitleHeader';
+
+type Props = {
+  chats: Chat[];
+  activeChatId: string | null;
+  onChatClick: (id: string) => void;
+  isCollapsed: boolean;
+};
+
+function ChatListItem({ chat, chats, depth, onChatClick, activeChatId, isCollapsed }: any) {
+  const children = chats.filter((c: Chat) => c.parentId === chat.id);
+  const paddingLeft = `${1 + depth * 1.5}rem`;
+  return (
+    <li>
+      <a
+        href="#"
+        onClick={(e) => { e.preventDefault(); onChatClick(chat.id); }}
+        className={`block truncate py-2 rounded-md ${activeChatId === chat.id ? 'bg-primary text-primary-foreground' : 'hover:bg-accent'} ${isCollapsed ? 'text-center px-0' : 'pr-4'}`}
+        style={{ paddingLeft: !isCollapsed ? paddingLeft : undefined }}
+        title={chat.title}
+      >
+        {isCollapsed ? chat.title.charAt(0).toUpperCase() : chat.title}
+      </a>
+      {!isCollapsed && children.length > 0 && (
+        <ul className="space-y-1 mt-1">
+          {children.map((child) => (
+            <ChatListItem
+              key={child.id}
+              chat={child}
+              chats={chats}
+              depth={depth + 1}
+              onChatClick={onChatClick}
+              activeChatId={activeChatId}
+              isCollapsed={isCollapsed}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+export default function ChatTree({ chats, activeChatId, onChatClick, isCollapsed }: Props) {
+  const rootChats = chats.filter((chat) => chat.parentId === null);
+  return (
+    <ul className="space-y-1 p-2">
+      {rootChats.map((chat) => (
+        <ChatListItem
+          key={chat.id}
+          chat={chat}
+          chats={chats}
+          depth={0}
+          onChatClick={onChatClick}
+          activeChatId={activeChatId}
+          isCollapsed={isCollapsed}
+        />
+      ))}
+    </ul>
+  );
+}
+

--- a/prototype/frontend/src/components/sidebar/SidebarHeader.tsx
+++ b/prototype/frontend/src/components/sidebar/SidebarHeader.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+type Props = {
+  isCollapsed: boolean;
+  onToggle: () => void;
+  onToggleTreeView: () => void;
+  onToggleCapture: () => void;
+};
+
+// Header controls for the sidebar: title, capture toggle, tree toggle, collapse toggle
+export default function SidebarHeader({ isCollapsed, onToggle, onToggleTreeView, onToggleCapture }: Props) {
+  return (
+    <div className="p-4 flex items-center justify-between flex-shrink-0">
+      {!isCollapsed && (
+        <h2 className="text-lg font-semibold transition-opacity duration-300 ease-out delay-100 opacity-100">
+          Chats
+        </h2>
+      )}
+      <div className="flex items-center gap-2">
+        {isCollapsed ? (
+          <button onClick={onToggle} className="text-muted-foreground hover:text-foreground" title="Expand sidebar" aria-label="Expand sidebar">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" /></svg>
+          </button>
+        ) : (
+          <div className="flex items-center gap-2 transition-all duration-300 ease-out delay-150 opacity-100 translate-x-0">
+            <button
+              onClick={onToggleCapture}
+              className="text-muted-foreground hover:text-foreground"
+              title="Toggle captured highlights"
+              aria-label="Toggle captured highlights"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <rect x="9" y="2" width="6" height="4" rx="1"/>
+                <path d="M9 2H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2h-2"/>
+              </svg>
+            </button>
+            <button onClick={onToggleTreeView} className="text-muted-foreground hover:text-foreground" title="Open tree view" aria-label="Open tree view">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M3 3v18h18"/>
+                <path d="M18 18v-9a4 4 0 0 0-4-4H3"/>
+              </svg>
+            </button>
+            <button onClick={onToggle} className="text-muted-foreground hover:text-foreground" title="Collapse sidebar" aria-label="Collapse sidebar">
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" /></svg>
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/prototype/frontend/src/lib/events.ts
+++ b/prototype/frontend/src/lib/events.ts
@@ -1,0 +1,8 @@
+export const CLIPBOARD_ADD_HIGHLIGHT = 'clipboard:add-highlight';
+
+export type AddHighlightDetail = { text: string; messageId?: string };
+
+export function dispatchAddHighlight(detail: AddHighlightDetail) {
+  window.dispatchEvent(new CustomEvent(CLIPBOARD_ADD_HIGHLIGHT, { detail }));
+}
+


### PR DESCRIPTION
Refactor and UX polish:

Add events helper (CLIPBOARD_ADD_HIGHLIGHT) at src/lib/events.ts 
Add HighlightText for inline gray highlights in user messages 
Split Sidebar into SidebarHeader, ChatTree, and CapturePanel 
ChatWindow: use HighlightText and dispatchAddHighlight for 'Add to clipboard' 
Sidebar: smoother width + content animations; collapsed state shows only expand toggle 
Capture panel: checkboxes + Discard/Create Branch (placeholder, no navigation) 

No dependency changes required.